### PR TITLE
feat: add configuration for augmenting global device context

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ As an example:
 dynamicRegistration:
   config:
   - address: udp://0.0.0.0:5566
+    context:
+      site: ke1-test
 ```
 
 Note that the IP address in this example is `0.0.0.0`. When running the plugin via a Docker
@@ -77,6 +79,7 @@ If no default is specified (`-`), the field is required.
 | Field   | Description | Default |
 | ------- | ----------- | ------- |
 | address | The protocol/address/port for the UDP server to listen for incoming telemetry data. The protocol may be one of: [`udp`, `udp4`, `udp6`]. When running in a docker container, the address should be `0.0.0.0`. | `-` |
+| context | Additional key-value pairs to be globally applied to all device contexts for devices managed by a plugin instance. | `{}` |
 
 ### Reading Outputs
 

--- a/example/config.yaml
+++ b/example/config.yaml
@@ -18,12 +18,14 @@ settings:
     # configured Juniper equipment reports data over the JTI stream.
     interval: 1s
   write:
-    enabled: false
+    disable: true
   listen:
-    enabled: false
+    disable: true
   cache:
     enabled: true
     ttl: 5m
 dynamicRegistration:
   config:
     - address: udp://0.0.0.0:5566
+      context:
+        site: ke1-test

--- a/pkg/actions.go
+++ b/pkg/actions.go
@@ -27,7 +27,7 @@ var RunBackgroundListener = sdk.PluginAction{
 		deviceManager := manager.NewPluginDeviceManager(p)
 
 		// Create the UDP server from the configuration.
-		svr := protocol.NewJtiUDPServer(serverConfig.Address, deviceManager)
+		svr := protocol.NewJtiUDPServer(serverConfig, deviceManager)
 
 		log.Info("[jti] starting UDP server listen")
 		go func() {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -20,7 +20,11 @@ type ServerConfig struct {
 	// Address for the UDP server to listen on. This should be a string specifying
 	// the IP/hostname and port. The protocol prefix may be one of: "udp", "udp4",
 	// "udp6". If unspecified, "udp" is used.
-	Address string
+	Address string `yaml:"address,omitempty"`
+
+	// Contexts allow users to define arbitrary context key-value pairs to be globally
+	// applied to the devices for a plugin instance.
+	Context map[string]string `yaml:"context,omitempty"`
 }
 
 // Load the configuration for the plugin's UDP server which will listen for the

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -15,6 +15,22 @@ func TestLoad_Ok(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, cfg)
 	assert.Equal(t, "localhost", cfg.Address)
+	assert.Empty(t, cfg.Context)
+}
+
+func TestLoad_Ok2(t *testing.T) {
+	raw := map[string]interface{}{
+		"address": "udp://1.2.3.4:30000",
+		"context": map[string]string{
+			"foo": "bar",
+		},
+	}
+
+	cfg, err := Load(raw)
+	assert.NoError(t, err)
+	assert.NotNil(t, cfg)
+	assert.Equal(t, "udp://1.2.3.4:30000", cfg.Address)
+	assert.Equal(t, map[string]string{"foo": "bar"}, cfg.Context)
 }
 
 func TestLoad_Error(t *testing.T) {

--- a/pkg/manager/stub.go
+++ b/pkg/manager/stub.go
@@ -32,7 +32,7 @@ func (dm *StubDeviceManager) NewDevice(proto *config.DeviceProto, inst *config.D
 	if dm.withError {
 		return nil, fmt.Errorf("error creating stub device")
 	}
-	return &sdk.Device{}, nil
+	return sdk.NewDeviceFromConfig(proto, inst, map[string]*sdk.DeviceHandler{"jti": {}})
 }
 
 // RegisterDevice registers an SDK Device.

--- a/pkg/protocol/udp_test.go
+++ b/pkg/protocol/udp_test.go
@@ -1,1 +1,211 @@
 package protocol
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/vapor-ware/synse-juniper-jti-plugin/pkg/config"
+	"github.com/vapor-ware/synse-juniper-jti-plugin/pkg/manager"
+	"github.com/vapor-ware/synse-juniper-jti-plugin/pkg/protocol/jti"
+)
+
+func TestNewJtiUDPServer(t *testing.T) {
+	svr := NewJtiUDPServer(
+		&config.ServerConfig{
+			Address: "localhost",
+			Context: map[string]string{
+				"site": "test",
+			},
+		},
+		manager.NewStubDeviceManager(false),
+	)
+
+	assert.Equal(t, svr.Address, "localhost")
+	assert.Equal(t, map[string]string{"site": "test"}, svr.GlobalContext)
+	assert.Equal(t, svr.BufferSize, uint64(64*1024))
+	assert.False(t, svr.stopped)
+	assert.Nil(t, svr.conn)
+	assert.NotNil(t, svr.decoder)
+	assert.NotNil(t, svr.deviceManager)
+}
+
+func TestJtiUDPServer_Stop_nilConn(t *testing.T) {
+	svr := JtiUDPServer{}
+	assert.False(t, svr.stopped)
+	assert.Nil(t, svr.conn)
+
+	svr.Stop()
+	assert.True(t, svr.stopped)
+}
+
+func TestJtiUDPServer_Stop(t *testing.T) {
+	svr := JtiUDPServer{
+		conn: &net.UDPConn{},
+	}
+	assert.False(t, svr.stopped)
+	assert.NotNil(t, svr.conn)
+
+	svr.Stop()
+	assert.True(t, svr.stopped)
+}
+
+func TestNewDeviceFromInfo(t *testing.T) {
+	// Context is only set via device info.
+
+	info := jti.DeviceInfo{
+		Type: "device-type",
+		Info: "device-info",
+		Tags: []string{
+			"a/b:c",
+		},
+		Context: map[string]string{
+			"device-ctx": "abc",
+		},
+		IDComponents: map[string]string{
+			"foo": "bar",
+		},
+	}
+
+	svr := JtiUDPServer{
+		GlobalContext: map[string]string{},
+		deviceManager: manager.NewStubDeviceManager(false),
+	}
+
+	dev, err := svr.newDeviceFromInfo(&info)
+	assert.NoError(t, err)
+	assert.Equal(t, "device-type", dev.Type)
+	assert.Equal(t, "device-info", dev.Info)
+	assert.Equal(t, "jti", dev.Handler)
+	assert.Equal(t, map[string]string{
+		"device-ctx": "abc",
+	}, dev.Context)
+	assert.Equal(t, map[string]interface{}{
+		"id": map[string]string{
+			"foo": "bar",
+		},
+	}, dev.Data)
+	assert.Len(t, dev.Tags, 1)
+	tag := dev.Tags[0]
+	assert.Equal(t, "a", tag.Namespace)
+	assert.Equal(t, "b", tag.Annotation)
+	assert.Equal(t, "c", tag.Label)
+}
+
+func TestNewDeviceFromInfo2(t *testing.T) {
+	// Context is only set via device info and global, no conflicts.
+
+	info := jti.DeviceInfo{
+		Type: "device-type",
+		Info: "device-info",
+		Tags: []string{
+			"a/b:c",
+		},
+		Context: map[string]string{
+			"device-ctx": "abc",
+		},
+		IDComponents: map[string]string{
+			"foo": "bar",
+		},
+	}
+
+	svr := JtiUDPServer{
+		GlobalContext: map[string]string{
+			"global-ctx": "123",
+		},
+		deviceManager: manager.NewStubDeviceManager(false),
+	}
+
+	dev, err := svr.newDeviceFromInfo(&info)
+	assert.NoError(t, err)
+	assert.Equal(t, "device-type", dev.Type)
+	assert.Equal(t, "device-info", dev.Info)
+	assert.Equal(t, "jti", dev.Handler)
+	assert.Equal(t, map[string]string{
+		"device-ctx": "abc",
+		"global-ctx": "123",
+	}, dev.Context)
+	assert.Equal(t, map[string]interface{}{
+		"id": map[string]string{
+			"foo": "bar",
+		},
+	}, dev.Data)
+	assert.Len(t, dev.Tags, 1)
+	tag := dev.Tags[0]
+	assert.Equal(t, "a", tag.Namespace)
+	assert.Equal(t, "b", tag.Annotation)
+	assert.Equal(t, "c", tag.Label)
+}
+
+func TestNewDeviceFromInfo3(t *testing.T) {
+	// Context is only set via device info and global, with conflicts.
+
+	info := jti.DeviceInfo{
+		Type: "device-type",
+		Info: "device-info",
+		Tags: []string{
+			"a/b:c",
+		},
+		Context: map[string]string{
+			"device-ctx": "abc",
+			"common":     "device-value",
+		},
+		IDComponents: map[string]string{
+			"foo": "bar",
+		},
+	}
+
+	svr := JtiUDPServer{
+		GlobalContext: map[string]string{
+			"global-ctx": "123",
+			"common":     "global-value",
+		},
+		deviceManager: manager.NewStubDeviceManager(false),
+	}
+
+	dev, err := svr.newDeviceFromInfo(&info)
+	assert.NoError(t, err)
+	assert.Equal(t, "device-type", dev.Type)
+	assert.Equal(t, "device-info", dev.Info)
+	assert.Equal(t, "jti", dev.Handler)
+	assert.Equal(t, map[string]string{
+		"device-ctx": "abc",
+		"global-ctx": "123",
+		"common":     "device-value",
+	}, dev.Context)
+	assert.Equal(t, map[string]interface{}{
+		"id": map[string]string{
+			"foo": "bar",
+		},
+	}, dev.Data)
+	assert.Len(t, dev.Tags, 1)
+	tag := dev.Tags[0]
+	assert.Equal(t, "a", tag.Namespace)
+	assert.Equal(t, "b", tag.Annotation)
+	assert.Equal(t, "c", tag.Label)
+}
+
+func TestNewDeviceFromInfo_Error(t *testing.T) {
+	info := jti.DeviceInfo{
+		Type: "device-type",
+		Info: "device-info",
+		Tags: []string{
+			"a/b:c",
+		},
+		Context: map[string]string{
+			"device-ctx": "abc",
+		},
+		IDComponents: map[string]string{
+			"foo": "bar",
+		},
+	}
+
+	svr := JtiUDPServer{
+		GlobalContext: map[string]string{},
+		deviceManager: manager.NewStubDeviceManager(true),
+	}
+
+	dev, err := svr.newDeviceFromInfo(&info)
+	assert.Error(t, err)
+	assert.Nil(t, dev)
+}


### PR DESCRIPTION
This PR
- adds support for configuring  global context  fields which are applied to all  devices (and subsequently  readings) for devices managed by a plugin instance.
- adds tests, updates readme